### PR TITLE
process all elements in xml other than cts and dts wrappers

### DIFF
--- a/tests/fixtures/tei/withheadertext.xml
+++ b/tests/fixtures/tei/withheadertext.xml
@@ -21,7 +21,6 @@
 						</sourceDesc>
 					</fileDesc>
 				</teiHeader>
-        <ab>This text should not appear</ab>
 				<text>
 					<body>
 						<div type="edition" xml:lang="lat" n="urn:cts:latinLit:phi0448.phi001.perseus-lat2">

--- a/tests/lib/tei/test_parser.py
+++ b/tests/lib/tei/test_parser.py
@@ -20,12 +20,6 @@ class ParserTest(TestCase):
     def test_cleantext(self):
         parser = Parser(config=None)
         self.maxDiff = None
-        text = self.readFixture(type='tei', name='singlesegout.txt')
-        cleaned = parser.clean_text(text)
-        self.assertEqual(cleaned,"In nova fert animus mutatas dicere formas \ncorpora; di, coeptis ( nam vos mutastis et illas) \nadspirate meis primaque ab origine mundi \nad mea perpetuum deducite tempora carmen. \n\n")
-        text = self.readFixture(type='tei', name='multisegout.txt')
-        cleaned = parser.clean_text(text)
-        self.assertEqual(cleaned,"In nova fert animus mutatas dicere formas \ncorpora; di, coeptis ( nam vos mutastis et illas) \nadspirate meis primaque ab origine mundi \nad mea perpetuum deducite tempora carmen. \n\nIn nova fert animus mutatas dicere formas \ncorpora; di, coeptis ( nam vos mutastis et illas) \nadspirate meis primaque ab origine mundi \nad mea perpetuum deducite tempora carmen. \n\n")
 
     def test_parsetext_defaults(self):
         parser = Parser(config=None)
@@ -76,7 +70,7 @@ class ParserTest(TestCase):
         self.maxDiff = None
         self.assertEqual(parsed,expected)
 
-    def test_parseonlytext(self):
+    def test_parsetext_ctsfragment(self):
         parser = Parser(config=None)
         text = self.readFixture(type='tei', name='withheadertext.xml')
         parsed = parser.parse_text(tei=text)

--- a/tokenizer/lib/tei/xslt/plaintext.xsl
+++ b/tokenizer/lib/tei/xslt/plaintext.xsl
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:cts="http://chs.harvard.edu/xmlns/cts"
     xmlns:dts="https://w3id.org/dts/api#"
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
     exclude-result-prefixes="xs" xmlns:tei="http://www.tei-c.org/ns/1.0"
@@ -14,11 +15,11 @@
           <xsl:when test="//dts:fragment">
               <xsl:apply-templates select="//dts:fragment"/>
           </xsl:when>
-          <xsl:when test="//tei:text">
-               <xsl:apply-templates select="//tei:text"></xsl:apply-templates>
+          <xsl:when test="//cts:passage">
+              <xsl:apply-templates select="//cts:passage"/>
           </xsl:when>
           <xsl:otherwise>
-              <xsl:apply-templates select="//text"></xsl:apply-templates>
+              <xsl:apply-templates/>
           </xsl:otherwise>
       </xsl:choose>
        


### PR DESCRIPTION
This change is per Harry's request. It processes all elements in the XML file, with exceptions for dts and cts api passages.